### PR TITLE
Add browser-based git patch helper

### DIFF
--- a/patcher.html
+++ b/patcher.html
@@ -1,0 +1,522 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Git Patch Helper</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #0f172a;
+      --surface: rgba(15, 23, 42, 0.75);
+      --card: rgba(15, 23, 42, 0.85);
+      --border: rgba(148, 163, 184, 0.3);
+      --text: #f8fafc;
+      --muted: #cbd5f5;
+      --accent: #38bdf8;
+      --error: #f87171;
+      --success: #4ade80;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+      background: radial-gradient(circle at top, #1e293b, #020617 65%);
+      color: var(--text);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 40px 18px;
+    }
+
+    .app {
+      width: min(960px, 100%);
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 22px;
+      box-shadow: 0 25px 60px rgba(2, 6, 23, 0.45);
+      backdrop-filter: blur(16px);
+      padding: 40px clamp(20px, 5vw, 48px);
+      display: grid;
+      gap: 28px;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: clamp(28px, 3.2vw, 36px);
+      font-weight: 700;
+      letter-spacing: 0.4px;
+    }
+
+    p.lead {
+      margin: 4px 0 0;
+      font-size: 16px;
+      color: rgba(226, 232, 240, 0.82);
+      line-height: 1.6;
+    }
+
+    label {
+      display: block;
+      font-weight: 600;
+      font-size: 15px;
+      margin-bottom: 12px;
+      color: rgba(226, 232, 240, 0.92);
+    }
+
+    textarea {
+      width: 100%;
+      min-height: clamp(220px, 40vh, 340px);
+      background: rgba(15, 23, 42, 0.55);
+      border: 1px solid rgba(148, 163, 184, 0.35);
+      border-radius: 16px;
+      color: var(--text);
+      font-family: "Fira Code", "SFMono-Regular", "Consolas", "Liberation Mono", monospace;
+      font-size: 14px;
+      line-height: 1.5;
+      padding: 16px;
+      resize: vertical;
+      outline: none;
+      transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    textarea:focus {
+      border-color: rgba(56, 189, 248, 0.65);
+      box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.35);
+    }
+
+    .file-picker {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      background: rgba(15, 23, 42, 0.55);
+      border: 1px dashed rgba(148, 163, 184, 0.45);
+      border-radius: 16px;
+      padding: 20px;
+    }
+
+    .file-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      align-items: center;
+    }
+
+    .file-actions label[for="fileInput"] {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 10px;
+      padding: 12px 20px;
+      background: rgba(56, 189, 248, 0.18);
+      border: 1px solid rgba(56, 189, 248, 0.45);
+      color: var(--text);
+      border-radius: 12px;
+      cursor: pointer;
+      transition: transform 0.15s ease, box-shadow 0.15s ease;
+    }
+
+    .file-actions label[for="fileInput"]:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 8px 20px rgba(14, 116, 144, 0.35);
+    }
+
+    .file-actions input[type="file"] {
+      display: none;
+    }
+
+    .file-name {
+      font-size: 14px;
+      color: rgba(226, 232, 240, 0.8);
+    }
+
+    button#applyBtn {
+      width: 100%;
+      padding: 18px clamp(12px, 4vw, 28px);
+      border-radius: 18px;
+      border: none;
+      font-size: clamp(18px, 2.4vw, 22px);
+      font-weight: 700;
+      letter-spacing: 0.6px;
+      text-transform: uppercase;
+      background: linear-gradient(135deg, #38bdf8 0%, #0ea5e9 40%, #0284c7 100%);
+      color: #0f172a;
+      cursor: pointer;
+      transition: transform 0.18s ease, box-shadow 0.18s ease, filter 0.18s ease;
+      box-shadow: 0 18px 36px rgba(14, 165, 233, 0.35);
+    }
+
+    button#applyBtn:disabled {
+      cursor: not-allowed;
+      filter: grayscale(0.35);
+      box-shadow: none;
+      opacity: 0.6;
+    }
+
+    button#applyBtn:not(:disabled):hover {
+      transform: translateY(-2px) scale(1.01);
+      box-shadow: 0 22px 40px rgba(14, 165, 233, 0.45);
+    }
+
+    .status {
+      min-height: 24px;
+      font-size: 15px;
+      font-weight: 500;
+      letter-spacing: 0.2px;
+    }
+
+    .status.success {
+      color: var(--success);
+    }
+
+    .status.error {
+      color: var(--error);
+    }
+
+    .status.muted {
+      color: rgba(148, 163, 184, 0.9);
+    }
+
+    @media (max-width: 640px) {
+      body {
+        padding: 20px 14px;
+      }
+
+      .app {
+        border-radius: 18px;
+        padding: 28px 18px;
+        gap: 20px;
+      }
+
+      button#applyBtn {
+        font-size: 18px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="app">
+    <header>
+      <h1>Patch an Uploaded File</h1>
+      <p class="lead">Paste a unified git patch, upload the current file version, then hit the big button to download the patched result.</p>
+    </header>
+
+    <section>
+      <label for="patchInput">Git patch</label>
+      <textarea id="patchInput" placeholder="Paste your git patch here (starting with diff --git or @@)..."></textarea>
+    </section>
+
+    <section class="file-picker">
+      <div class="file-actions">
+        <label for="fileInput" id="fileLabel">📁 Upload current file</label>
+        <input id="fileInput" type="file" />
+        <div class="file-name" id="fileName">No file selected yet.</div>
+      </div>
+      <div class="status muted" id="fileStatus">Waiting for file upload…</div>
+    </section>
+
+    <button id="applyBtn" type="button" disabled>PATCH Uploaded File</button>
+
+    <div class="status" id="statusMessage" role="status" aria-live="polite"></div>
+  </main>
+
+  <script>
+    (function () {
+      const patchInput = document.getElementById('patchInput');
+      const fileInput = document.getElementById('fileInput');
+      const fileNameEl = document.getElementById('fileName');
+      const fileStatusEl = document.getElementById('fileStatus');
+      const statusEl = document.getElementById('statusMessage');
+      const applyBtn = document.getElementById('applyBtn');
+
+      let uploadedContent = '';
+      let uploadedFileName = '';
+      let hasFile = false;
+      const originalBtnText = applyBtn.textContent;
+
+      fileInput.addEventListener('change', () => {
+        clearStatus();
+        const file = fileInput.files && fileInput.files[0];
+        if (!file) {
+          hasFile = false;
+          uploadedContent = '';
+          uploadedFileName = '';
+          fileNameEl.textContent = 'No file selected yet.';
+          fileStatusEl.textContent = 'Waiting for file upload…';
+          fileStatusEl.className = 'status muted';
+          updateButtonState();
+          return;
+        }
+
+        fileNameEl.textContent = `Reading “${file.name}”…`;
+        fileStatusEl.textContent = 'Loading file content…';
+        fileStatusEl.className = 'status muted';
+
+        const reader = new FileReader();
+        reader.onload = () => {
+          uploadedContent = typeof reader.result === 'string' ? reader.result : '';
+          uploadedFileName = file.name;
+          hasFile = true;
+          fileNameEl.textContent = `${file.name} · ${formatBytes(file.size)}`;
+          fileStatusEl.textContent = 'File ready to patch.';
+          fileStatusEl.className = 'status success';
+          updateButtonState();
+        };
+        reader.onerror = () => {
+          hasFile = false;
+          uploadedContent = '';
+          uploadedFileName = '';
+          console.error(reader.error);
+          fileStatusEl.textContent = 'Failed to read file. Please try again.';
+          fileStatusEl.className = 'status error';
+          updateButtonState();
+        };
+        reader.readAsText(file);
+      });
+
+      patchInput.addEventListener('input', updateButtonState);
+
+      applyBtn.addEventListener('click', () => {
+        clearStatus();
+        const patchText = patchInput.value;
+        if (!patchText.trim()) {
+          setStatus('Paste a git patch before patching the file.', 'error');
+          return;
+        }
+        if (!hasFile) {
+          setStatus('Upload the current file you want to patch.', 'error');
+          return;
+        }
+
+        applyBtn.disabled = true;
+        applyBtn.textContent = 'Patching…';
+
+        try {
+          const patchedContent = applyPatch(uploadedContent, patchText);
+          triggerDownload(patchedContent, uploadedFileName);
+          setStatus('Patch applied. Your download should begin automatically.', 'success');
+        } catch (error) {
+          console.error(error);
+          setStatus(error && error.message ? error.message : String(error), 'error');
+        } finally {
+          applyBtn.textContent = originalBtnText;
+          applyBtn.disabled = false;
+          updateButtonState();
+        }
+      });
+
+      function updateButtonState() {
+        const hasPatch = patchInput.value.trim().length > 0;
+        applyBtn.disabled = !(hasPatch && hasFile);
+      }
+
+      function clearStatus() {
+        statusEl.textContent = '';
+        statusEl.className = 'status';
+      }
+
+      function setStatus(message, type) {
+        statusEl.textContent = message;
+        statusEl.className = `status ${type || ''}`.trim();
+      }
+
+      function triggerDownload(content, originalName) {
+        const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = derivePatchedName(originalName);
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        setTimeout(() => URL.revokeObjectURL(url), 1500);
+      }
+
+      function derivePatchedName(name) {
+        if (!name) {
+          return 'patched.txt';
+        }
+        const dot = name.lastIndexOf('.');
+        if (dot > 0 && dot < name.length - 1) {
+          return `${name.slice(0, dot)}.patched${name.slice(dot)}`;
+        }
+        return `${name}.patched`;
+      }
+
+      function formatBytes(bytes) {
+        if (!Number.isFinite(bytes)) {
+          return '';
+        }
+        if (bytes < 1024) {
+          return `${bytes} B`;
+        }
+        const units = ['KB', 'MB', 'GB', 'TB'];
+        let value = bytes;
+        let unitIndex = -1;
+        while (value >= 1024 && unitIndex < units.length - 1) {
+          value /= 1024;
+          unitIndex += 1;
+        }
+        const precision = value < 10 ? 2 : value < 100 ? 1 : 0;
+        return `${value.toFixed(precision)} ${units[unitIndex]}`;
+      }
+
+      function applyPatch(originalText, diffText) {
+        if (typeof diffText !== 'string' || diffText.trim() === '') {
+          throw new Error('Patch data is empty.');
+        }
+
+        const normalizedOriginal = (originalText || '').replace(/\r\n/g, '\n');
+        const normalizedDiff = diffText.replace(/\r\n/g, '\n');
+
+        const originalEndsWithNewline = normalizedOriginal.endsWith('\n');
+        const originalBody = originalEndsWithNewline
+          ? normalizedOriginal.slice(0, -1)
+          : normalizedOriginal;
+        const originalLines = originalBody.length > 0 ? originalBody.split('\n') : [];
+
+        const hunks = [];
+        const diffLines = normalizedDiff.split('\n');
+        let currentHunk = null;
+        let encounteredHunk = false;
+
+        for (let i = 0; i < diffLines.length; i += 1) {
+          const line = diffLines[i];
+
+          if (line.startsWith('diff --git') && encounteredHunk) {
+            break; // stop at next file diff
+          }
+
+          if (line.startsWith('@@')) {
+            const match = /@@ -([0-9]+)(?:,([0-9]+))? \+([0-9]+)(?:,([0-9]+))? @@/.exec(line);
+            if (!match) {
+              throw new Error(`Invalid hunk header: ${line}`);
+            }
+            currentHunk = {
+              oldStart: parseInt(match[1], 10),
+              oldCount: match[2] ? parseInt(match[2], 10) : 1,
+              newStart: parseInt(match[3], 10),
+              newCount: match[4] ? parseInt(match[4], 10) : 1,
+              lines: [],
+              newFileNoNewline: false,
+            };
+            hunks.push(currentHunk);
+            encounteredHunk = true;
+            continue;
+          }
+
+          if (!currentHunk) {
+            // Skip metadata until first hunk
+            continue;
+          }
+
+          if (line === '\\ No newline at end of file') {
+            if (currentHunk.lines.length > 0) {
+              const last = currentHunk.lines[currentHunk.lines.length - 1];
+              if (last && (last[0] === '+' || last[0] === ' ')) {
+                currentHunk.newFileNoNewline = true;
+              }
+            }
+            continue;
+          }
+
+          if (
+            line.startsWith('--- ') ||
+            line.startsWith('+++ ') ||
+            line.startsWith('index ') ||
+            line.startsWith('new file mode') ||
+            line.startsWith('deleted file mode')
+          ) {
+            continue;
+          }
+
+          if (line === '' && i === diffLines.length - 1) {
+            continue; // trailing newline of diff text
+          }
+
+          const marker = line[0];
+          if (marker === ' ' || marker === '+' || marker === '-') {
+            currentHunk.lines.push(line);
+          } else {
+            throw new Error(`Unexpected diff line: ${line}`);
+          }
+        }
+
+        if (!hunks.length) {
+          throw new Error('No hunks found in patch. Make sure it is a unified diff.');
+        }
+
+        const resultLines = [];
+        const totalOriginalLines = originalLines.length;
+        let cursor = 0;
+        let resultEndsWithNewline = originalEndsWithNewline;
+
+        for (const hunk of hunks) {
+          const oldStartIndex = hunk.oldStart <= 0 ? 0 : hunk.oldStart - 1;
+          if (oldStartIndex > totalOriginalLines) {
+            throw new Error('Hunk starts beyond the end of the file.');
+          }
+
+          while (cursor < oldStartIndex) {
+            resultLines.push(originalLines[cursor]);
+            cursor += 1;
+          }
+
+          for (const hunkLine of hunk.lines) {
+            const type = hunkLine[0];
+            const content = hunkLine.slice(1);
+            if (type === ' ') {
+              if (cursor >= originalLines.length) {
+                throw new Error('Patch references context beyond end of file.');
+              }
+              const originalLine = originalLines[cursor];
+              if (originalLine !== content) {
+                throw new Error(`Context mismatch near original line ${cursor + 1}.`);
+              }
+              resultLines.push(originalLine);
+              cursor += 1;
+            } else if (type === '-') {
+              if (cursor >= originalLines.length) {
+                throw new Error('Patch tries to remove lines beyond end of file.');
+              }
+              const originalLine = originalLines[cursor];
+              if (originalLine !== content) {
+                throw new Error(`Removal mismatch near original line ${cursor + 1}.`);
+              }
+              cursor += 1;
+            } else if (type === '+') {
+              resultLines.push(content);
+            } else {
+              throw new Error(`Unknown diff marker: ${type}`);
+            }
+          }
+
+          const indexForEnd = hunk.oldStart <= 0 ? 0 : hunk.oldStart - 1;
+          const touchesEnd = hunk.oldCount === 0
+            ? indexForEnd >= totalOriginalLines
+            : (indexForEnd + hunk.oldCount) >= totalOriginalLines;
+
+          if (touchesEnd) {
+            resultEndsWithNewline = !hunk.newFileNoNewline;
+          }
+        }
+
+        while (cursor < originalLines.length) {
+          resultLines.push(originalLines[cursor]);
+          cursor += 1;
+        }
+
+        if (!resultLines.length) {
+          return '';
+        }
+
+        let resultText = resultLines.join('\n');
+        if (resultEndsWithNewline) {
+          resultText += '\n';
+        }
+        return resultText;
+      }
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone `patcher.html` utility with styling, textarea, and upload workflow for patching files in the browser
- implement client-side logic to read the uploaded file, apply a unified diff patch, and trigger a download of the patched file

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ca8b0ff1dc8332aaddd27b9d733c1d